### PR TITLE
WebSocket Bug Fix // Cost Basis

### DIFF
--- a/src/api/gdax.js
+++ b/src/api/gdax.js
@@ -58,18 +58,11 @@ async function listOrders(client, mode = 'json') {
 function executeTwoLegTrade(
         auth,
         client,
-        profit,
         product,
-        entryTradeParams,
-        exitTradeParams) {
+        tradePairs,
+        mode = 'json') {
 
-    let buyOrderId;
-    let sellOrderId;
-    let buyMode = true;
-    let monitorSellMode = false;
-    let orderSubmitted = false;
-    let sellOrderSubmitted = false;
-
+    let summary = false;
     const websocket = new Gdax.WebsocketClient(
         [product],
         'wss://ws-feed.gdax.com',
@@ -82,35 +75,72 @@ function executeTwoLegTrade(
     websocket.on('message', async (data) => {
         try {
             if(data.type === 'ticker') {
-                if(buyMode && !orderSubmitted) {
-                    console.log(`Found Entry Price, submitting order at ${entryTradeParams.price}`);
-                    orderSubmitted = true;
-                    buyOrderId = await client.placeOrder(entryTradeParams);
-                    output('table', [buyOrderId]);
-                    buyMode = false;
-                } else {
-                    if(!monitorSellMode && buyOrderId && buyOrderId.id) {
-                        const buyOrder = await client.getOrder(buyOrderId.id);
-                        if(buyOrder.status === "rejected") {
-                            console.log("Failed to buy at params");
-                        }
-                        if(buyOrder.settled === true && !sellOrderSubmitted) {
-                            sellOrderSubmitted = true;
-                            sellOrderId = await client.placeOrder(exitTradeParams);
-                            output('table', [sellOrderId]);
-                            monitorSellMode = true;
-                        }
+
+                const updatedTradePairs = await Aigle.map(tradePairs, async (pair) => {
+
+                    let buyOrderId = pair.buyOrderId;
+                    let sellOrderId = pair.sellOrderId;
+                    let buyMode = _.get(pair, "buyMode" , true);
+                    let monitorSellMode = _.get(pair, "monitorSellMode", false);
+                    let orderSubmitted = _.get(pair, "orderSubmitted", false);
+                    let sellOrderSubmitted = _.get(pair, "sellOrderSubmitted", false);
+
+                    if(_.isUndefined(pair.profit)) {
+                        const profit = (pair.sell.price * pair.sell.size) - (pair.buy.price * pair.buy.size);
+                        //console.log("Profit for order: ", profit);
+                        pair.profit = profit;
+                    }
+
+                    if(buyMode && !orderSubmitted) {
+                        console.log(`Found Entry Price, submitting order at ${pair.buy.price}`);
+                        pair.orderSubmitted = true;
+                        pair.buyOrderId = await client.placeOrder(pair.buy);
+                        //output('table', [pair.buyOrderId]);
+                        pair.buyMode = false;
                     } else {
-                        const sellOrder = await client.getOrder(sellOrderId.id);
-                        if(sellOrder.status === "rejected") {
-                            monitorSellMode = false;
-                            sellOrderSubmitted = false;
-                        }
-                        if(sellOrder.settled === true) {
-                            console.log(`Order by id: ${sellOrder.id} complete with $${profit} USD`);
+                        if(!monitorSellMode) {
+                            // console.log("Monitoring Sell Mode");
+                            // console.log("BuyOrderId: ", buyOrderId);
+                            if( !_.isUndefined(buyOrderId) && !_.isUndefined(buyOrderId.id))
+                            {
+                                const buyOrder = await client.getOrder(buyOrderId.id);
+                                if(buyOrder.status === "rejected") {
+                                    console.log("Failed to buy at params");
+                                }
+                                if(buyOrder.settled === true && !sellOrderSubmitted) {
+                                    console.log("Sending Sell Order");
+                                    pair.sellOrderSubmitted = true;
+                                    pair.sellOrderId = await client.placeOrder(pair.sell);
+                                    output(mode, [sellOrderId]);
+                                    pair.monitorSellMode = true;
+                                }
+                            }
+                        } else if (monitorSellMode) {
+                            if(!_.isUndefined(sellOrderId) && !_.isUndefined(sellOrderId.id)) {
+                                const sellOrder = await client.getOrder(sellOrderId.id);
+                                if (sellOrder.status === "rejected") {
+                                    pair.monitorSellMode = false;
+                                    pair.sellOrderSubmitted = false;
+                                }
+                                if (sellOrder.settled === true) {
+                                    console.log(`Order by id: ${sellOrder.id} complete with $${pair.profit} USD`);
+                                }
+                            }
+                        } else {
+                            console.log("Unhandled....");
                         }
                     }
+
+                    return pair;
+                });
+
+                // Functional no-no we are modifying the heck out of this state.
+                tradePairs = updatedTradePairs;
+                if(!summary) {
+                    output(mode, tradePairs, "profit", ["buyOrderId"]);
+                    summary = true;
                 }
+
             }
         } catch (error) {
             console.log("Error while obtaining order details on a ticker update: ", error);
@@ -214,6 +244,9 @@ async function listCostBasis(client, mode = 'json', product) {
                     }
                 });
                 const relevantTrades = _.filter(tradesWithInfo, (twi) => {
+                    if( parseFloat(twi.amount) <= 0 ) {
+                        return false;
+                    }
                     if(productPosition <= 0 ) {
                         return false
                     } else {

--- a/src/trade.cmd.js
+++ b/src/trade.cmd.js
@@ -243,24 +243,10 @@ if(
         };
     });
 
-
-    const orders = _.map(twoLegPairs, (pair) => {
-        const profit = (pair.sell.price * pair.sell.size) - (pair.buy.price * pair.buy.size);
-        console.log("Profit for order: ", profit);
-        const trade = gdax.executeTwoLegTrade(
-            AuthUtils.getCredentials(commander.authFile),
-            AuthUtils.getAuthenticatedClient(false, commander.real, commander.authFile),
-            profit,
-            product,
-            pair.buy,
-            pair.sell);
-
-        return {
-            profit, trade,
-            sell: pair.sell,
-            buy: pair.buy
-        }
-    });
-
-    gdax.output(determineOutputMode(commander), orders, "profit");
+    gdax.executeTwoLegTrade(
+        AuthUtils.getCredentials(commander.authFile),
+        AuthUtils.getAuthenticatedClient(false, commander.real, commander.authFile),
+        product,
+        twoLegPairs,
+        determineOutputMode(commander));
 }


### PR DESCRIPTION
## SUMMARY

Fixing an issue where one websocket was open for each trade instead of iteration through all the trade pairs inside one websocket. This caused rate limiting errors and we can now support trades with levels easily over 25 and possibly up to 100.

Ignoring sell trades in price fills when calculating your average cost-basis for open positions in the calculator.